### PR TITLE
Do not set CCACHE_DIR

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -6,7 +6,7 @@ on:
       - .github/workflows/build-test.yml
       - .github/workflows/docker_image_build.yml
       - Dockerfile
-      - Rakefile
+      - entrypoint.rb
 
 jobs:
   build:

--- a/entrypoint.rb
+++ b/entrypoint.rb
@@ -12,12 +12,6 @@ ENV["MRUBY_CONFIG"] = build_config
 ENV["MRUBY_BUILD_DIR"] = build_dir
 ENV["INSTALL_DIR"] = install_dir
 
-if ENV["USE_CCACHE"]
-  ccache_dir = File.expand_path("build/ccache")
-  FileUtils.mkdir_p(ccache_dir)
-  ENV["CCACHE_DIR"] = ccache_dir
-end
-
 task = ARGV.first || "all"
 
 load "#{mruby_root}/Rakefile"


### PR DESCRIPTION
zigを使ってクロスビルドする場合同じccache_dirを使いエラーになってしまうので、実行時に変更できるようにする。

設定例:

```
# build_config.rb
conf.cc.command = "ccache -d build/ccache/host -- zig cc
```